### PR TITLE
Add Composer Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "friendlyis/mauticmultidomain",
+  "type": "mautic-plugin",
+  "license": "MIT",
+  "extra": {
+    "install-directory-name": "MauticMultiDomainBundle"
+  },
+  "require": {
+    "mautic/composer-plugin": "*"
+  }
+}


### PR DESCRIPTION
Adds support for composer, enables installation via:

```shell
# latest stable/tagged version
composer require friendlyis/mauticmultidomain
# or to track a branch
composer require friendlyis/mauticmultidomain:dev-main

```